### PR TITLE
RPM now installs etcd.conf and etcd.service. Bug fixes for build.sh

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV GITBUB_URL="https://github.com/etcd-io/etcd/releases/download"
+ENV GITHUB_URL="https://github.com/etcd-io/etcd/releases/download"
 ENV ETCD_VER="v3.4.13"
 ENV ETCD_ARCH="amd64"
 ENV ETCD_URL="${GITHUB_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-${ETCD_ARCH}.tar.gz"
@@ -20,6 +20,8 @@ RUN yum -y install rpm-build rpm-devel rpmlint rpmdevtools \
     && cp /root/rpmbuild/BUILD/etcd-${ETCD_VER}-linux-${ETCD_ARCH}/etcdctl /root/rpmbuild/BUILD/
 
 COPY etcd.spec /root/rpmbuild/SPECS/
+COPY etcd.service /root/rpmbuild/BUILD/
+COPY etcd.conf /root/rpmbuild/BUILD/
 COPY docker-entrypoint.sh /usr/local/bin/
 
 RUN cd rpmbuild \

--- a/centos/7/docker-entrypoint.sh
+++ b/centos/7/docker-entrypoint.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-cp /root/rpmbuild/RPMS/x86_64/*.rpm ${OUTPUT_PATH}/
+cp /root/rpmbuild/RPMS/x86_64/*.rpm ${CONTAINER_PATH}/

--- a/centos/7/etcd.conf
+++ b/centos/7/etcd.conf
@@ -1,0 +1,143 @@
+# This is the configuration file for the etcd server.
+# Sourced from here: https://github.com/etcd-io/etcd/blob/release-3.4/etcd.conf.yml.sample
+
+# Human-readable name for this member.
+name: 'default'
+
+# Path to the data directory.
+data-dir: /var/lib/etcd
+
+# Path to the dedicated wal directory.
+wal-dir:
+
+# Number of committed transactions to trigger a snapshot to disk.
+snapshot-count: 10000
+
+# Time (in milliseconds) of a heartbeat interval.
+heartbeat-interval: 100
+
+# Time (in milliseconds) for an election to timeout.
+election-timeout: 1000
+
+# Raise alarms when backend size exceeds the given quota. 0 means use the
+# default quota.
+quota-backend-bytes: 0
+
+# List of comma separated URLs to listen on for peer traffic.
+# By default, we listen on localhost
+listen-peer-urls: http://localhost:2380
+
+# List of comma separated URLs to listen on for client traffic.
+# By default, we listen on localhost
+listen-client-urls: http://localhost:2379
+
+# Maximum number of snapshot files to retain (0 is unlimited).
+max-snapshots: 5
+
+# Maximum number of wal files to retain (0 is unlimited).
+max-wals: 5
+
+# Comma-separated white list of origins for CORS (cross-origin resource sharing).
+cors:
+
+# List of this member's peer URLs to advertise to the rest of the cluster.
+# The URLs needed to be a comma-separated list.
+initial-advertise-peer-urls: http://localhost:2380
+
+# List of this member's client URLs to advertise to the public.
+# The URLs needed to be a comma-separated list.
+advertise-client-urls: http://localhost:2379
+
+# Discovery URL used to bootstrap the cluster.
+discovery:
+
+# Valid values include 'exit', 'proxy'
+discovery-fallback: 'proxy'
+
+# HTTP proxy to use for traffic to discovery service.
+discovery-proxy:
+
+# DNS domain used to bootstrap initial cluster.
+discovery-srv:
+
+# Initial cluster configuration for bootstrapping.
+initial-cluster:
+
+# Initial cluster token for the etcd cluster during bootstrap.
+initial-cluster-token: 'etcd-cluster'
+
+# Initial cluster state ('new' or 'existing').
+initial-cluster-state: 'new'
+
+# Reject reconfiguration requests that would cause quorum loss.
+strict-reconfig-check: false
+
+# Accept etcd V2 client requests
+enable-v2: true
+
+# Enable runtime profiling data via HTTP server
+enable-pprof: true
+
+# Valid values include 'on', 'readonly', 'off'
+proxy: 'off'
+
+# Time (in milliseconds) an endpoint will be held in a failed state.
+proxy-failure-wait: 5000
+
+# Time (in milliseconds) of the endpoints refresh interval.
+proxy-refresh-interval: 30000
+
+# Time (in milliseconds) for a dial to timeout.
+proxy-dial-timeout: 1000
+
+# Time (in milliseconds) for a write to timeout.
+proxy-write-timeout: 5000
+
+# Time (in milliseconds) for a read to timeout.
+proxy-read-timeout: 0
+
+client-transport-security:
+  # Path to the client server TLS cert file.
+  cert-file:
+
+  # Path to the client server TLS key file.
+  key-file:
+
+  # Enable client cert authentication.
+  client-cert-auth: false
+
+  # Path to the client server TLS trusted CA cert file.
+  trusted-ca-file:
+
+  # Client TLS using generated certificates
+  auto-tls: false
+
+peer-transport-security:
+  # Path to the peer server TLS cert file.
+  cert-file:
+
+  # Path to the peer server TLS key file.
+  key-file:
+
+  # Enable peer client cert authentication.
+  client-cert-auth: false
+
+  # Path to the peer server TLS trusted CA cert file.
+  trusted-ca-file:
+
+  # Peer TLS using generated certificates.
+  auto-tls: false
+
+# Enable debug-level logging for etcd.
+debug: false
+
+logger: zap
+
+# Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.
+log-outputs: [stderr]
+
+# Force to create a new one member cluster.
+force-new-cluster: false
+
+auto-compaction-mode: periodic
+auto-compaction-retention: "1"

--- a/centos/7/etcd.service
+++ b/centos/7/etcd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=etcd  kev-value store
+Documentation=https://github.com/coreos/etcd
+After=network.target
+ 
+[Service]
+User=etcd
+Type=notify
+ExecStart=/usr/local/bin/etcd
+Restart=on-failure
+RestartSec=5
+Environment=ETCD_CONFIG_FILE=/etc/etcd.d/etcd.conf
+LimitNOFILE=40000
+ 
+[Install]
+WantedBy=multi-user.target

--- a/centos/7/etcd.spec
+++ b/centos/7/etcd.spec
@@ -11,16 +11,36 @@ Secure: automatic TLS with optional client cert authentication
 Fast: benchmarked 10,000 writes/sec
 Reliable: properly distributed using Raft
 
+%pre 
+if [ $(grep -c ^etcd /etc/passwd) == 0 ]; then
+    /sbin/useradd --shell /sbin/nologin --no-create-home etcd
+fi
 %prep
-
+if [ $(grep -c ^etcd /etc/passwd) == 0 ]; then
+    /sbin/useradd --shell /sbin/nologin --no-create-home etcd
+fi
 %build
 
 %install
+if [ $(grep -c ^etcd /etc/passwd) == 0 ]; then
+    /sbin/useradd --shell /sbin/nologin --no-create-home etcd
+fi
 mkdir -p %{buildroot}/usr/local/bin
+mkdir -p %{buildroot}/etc/etcd.d
+mkdir -p %{buildroot}/var/lib/etcd
+mkdir -p %{buildroot}/usr/lib/systemd/system
+
 install -m 755 etcdctl %{buildroot}/usr/local/bin/etcdctl
 install -m 755 etcd %{buildroot}/usr/local/bin/etcd
+install -m 0600 -o etcd -g root etcd.conf %{buildroot}/etc/etcd.d/etcd.conf
+install -m 0644 etcd.service %{buildroot}/usr/lib/systemd/system
+install -d -m 0750 -o etcd -g root %{buildroot}/var/lib/etcd
 
 %files
-/usr/local/bin/etcdctl
-/usr/local/bin/etcd
+%attr(0755, root, root) /usr/local/bin/etcdctl
+%attr(0755, root, root) /usr/local/bin/etcd
+%attr(0644, root, root) /etc/etcd.d/etcd.conf
+/usr/lib/systemd/system/etcd.service
+%attr(0750, etcd, root) /var/lib/etcd
+
 %changelog

--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -1,9 +1,9 @@
 FROM centos:8
 
-ENV ETCD_URL="https://github.com/etcd-io/etcd/releases/download"
+ENV GITHUB_URL="https://github.com/etcd-io/etcd/releases/download"
 ENV ETCD_VER="v3.4.13"
 ENV ETCD_ARCH="amd64"
-ENV ETCD_URL="${ETCD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-${ETCD_ARCH}.tar.gz"
+ENV ETCD_URL="${GITHUB_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-${ETCD_ARCH}.tar.gz"
 # The path inside the container where the rpm is copied to
 ENV CONTAINER_PATH="/built_rpms"
 
@@ -20,6 +20,9 @@ RUN yum -y install rpm-build rpm-devel rpmlint rpmdevtools \
     && cp /root/rpmbuild/BUILD/etcd-${ETCD_VER}-linux-${ETCD_ARCH}/etcdctl /root/rpmbuild/BUILD/
 
 COPY etcd.spec /root/rpmbuild/SPECS/
+COPY etcd.service /root/rpmbuild/BUILD/
+COPY etcd.conf /root/rpmbuild/BUILD/
+
 COPY docker-entrypoint.sh /usr/local/bin/
 
 RUN cd rpmbuild \

--- a/centos/8/etcd.conf
+++ b/centos/8/etcd.conf
@@ -1,0 +1,143 @@
+# This is the configuration file for the etcd server.
+# Sourced from here: https://github.com/etcd-io/etcd/blob/release-3.4/etcd.conf.yml.sample
+
+# Human-readable name for this member.
+name: 'default'
+
+# Path to the data directory.
+data-dir: /var/lib/etcd
+
+# Path to the dedicated wal directory.
+wal-dir:
+
+# Number of committed transactions to trigger a snapshot to disk.
+snapshot-count: 10000
+
+# Time (in milliseconds) of a heartbeat interval.
+heartbeat-interval: 100
+
+# Time (in milliseconds) for an election to timeout.
+election-timeout: 1000
+
+# Raise alarms when backend size exceeds the given quota. 0 means use the
+# default quota.
+quota-backend-bytes: 0
+
+# List of comma separated URLs to listen on for peer traffic.
+# By default, we listen on localhost
+listen-peer-urls: http://localhost:2380
+
+# List of comma separated URLs to listen on for client traffic.
+# By default, we listen on localhost
+listen-client-urls: http://localhost:2379
+
+# Maximum number of snapshot files to retain (0 is unlimited).
+max-snapshots: 5
+
+# Maximum number of wal files to retain (0 is unlimited).
+max-wals: 5
+
+# Comma-separated white list of origins for CORS (cross-origin resource sharing).
+cors:
+
+# List of this member's peer URLs to advertise to the rest of the cluster.
+# The URLs needed to be a comma-separated list.
+initial-advertise-peer-urls: http://localhost:2380
+
+# List of this member's client URLs to advertise to the public.
+# The URLs needed to be a comma-separated list.
+advertise-client-urls: http://localhost:2379
+
+# Discovery URL used to bootstrap the cluster.
+discovery:
+
+# Valid values include 'exit', 'proxy'
+discovery-fallback: 'proxy'
+
+# HTTP proxy to use for traffic to discovery service.
+discovery-proxy:
+
+# DNS domain used to bootstrap initial cluster.
+discovery-srv:
+
+# Initial cluster configuration for bootstrapping.
+initial-cluster:
+
+# Initial cluster token for the etcd cluster during bootstrap.
+initial-cluster-token: 'etcd-cluster'
+
+# Initial cluster state ('new' or 'existing').
+initial-cluster-state: 'new'
+
+# Reject reconfiguration requests that would cause quorum loss.
+strict-reconfig-check: false
+
+# Accept etcd V2 client requests
+enable-v2: true
+
+# Enable runtime profiling data via HTTP server
+enable-pprof: true
+
+# Valid values include 'on', 'readonly', 'off'
+proxy: 'off'
+
+# Time (in milliseconds) an endpoint will be held in a failed state.
+proxy-failure-wait: 5000
+
+# Time (in milliseconds) of the endpoints refresh interval.
+proxy-refresh-interval: 30000
+
+# Time (in milliseconds) for a dial to timeout.
+proxy-dial-timeout: 1000
+
+# Time (in milliseconds) for a write to timeout.
+proxy-write-timeout: 5000
+
+# Time (in milliseconds) for a read to timeout.
+proxy-read-timeout: 0
+
+client-transport-security:
+  # Path to the client server TLS cert file.
+  cert-file:
+
+  # Path to the client server TLS key file.
+  key-file:
+
+  # Enable client cert authentication.
+  client-cert-auth: false
+
+  # Path to the client server TLS trusted CA cert file.
+  trusted-ca-file:
+
+  # Client TLS using generated certificates
+  auto-tls: false
+
+peer-transport-security:
+  # Path to the peer server TLS cert file.
+  cert-file:
+
+  # Path to the peer server TLS key file.
+  key-file:
+
+  # Enable peer client cert authentication.
+  client-cert-auth: false
+
+  # Path to the peer server TLS trusted CA cert file.
+  trusted-ca-file:
+
+  # Peer TLS using generated certificates.
+  auto-tls: false
+
+# Enable debug-level logging for etcd.
+debug: false
+
+logger: zap
+
+# Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.
+log-outputs: [stderr]
+
+# Force to create a new one member cluster.
+force-new-cluster: false
+
+auto-compaction-mode: periodic
+auto-compaction-retention: "1"

--- a/centos/8/etcd.service
+++ b/centos/8/etcd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=etcd  kev-value store
+Documentation=https://github.com/coreos/etcd
+After=network.target
+ 
+[Service]
+User=etcd
+Type=notify
+ExecStart=/usr/local/bin/etcd
+Restart=on-failure
+RestartSec=5
+Environment=ETCD_CONFIG_FILE=/etc/etcd.d/etcd.conf
+LimitNOFILE=40000
+ 
+[Install]
+WantedBy=multi-user.target

--- a/centos/8/etcd.spec
+++ b/centos/8/etcd.spec
@@ -2,22 +2,45 @@ Name:       etcd
 Version:    v3.4.13
 Release:    1
 Summary:    etcd - a distributed, reliable key/value store
-License:    Apache License Version 2
+License:    Apache License - Version 2
 
 %description
-etcd
+etcd is a distributed reliable key-value store for the most critical data of a distributed system, with a focus on being:
+Simple: well-defined, user-facing API (gRPC)
+Secure: automatic TLS with optional client cert authentication
+Fast: benchmarked 10,000 writes/sec
+Reliable: properly distributed using Raft
 
+%pre 
+if [ $(grep -c ^etcd /etc/passwd) == 0 ]; then
+    /sbin/useradd --shell /sbin/nologin --no-create-home etcd
+fi
 %prep
-# we have no source, so nothing here
-
+if [ $(grep -c ^etcd /etc/passwd) == 0 ]; then
+    /sbin/useradd --shell /sbin/nologin --no-create-home etcd
+fi
 %build
 
 %install
+if [ $(grep -c ^etcd /etc/passwd) == 0 ]; then
+    /sbin/useradd --shell /sbin/nologin --no-create-home etcd
+fi
 mkdir -p %{buildroot}/usr/local/bin
+mkdir -p %{buildroot}/etc/etcd.d
+mkdir -p %{buildroot}/var/lib/etcd
+mkdir -p %{buildroot}/usr/lib/systemd/system
+
 install -m 755 etcdctl %{buildroot}/usr/local/bin/etcdctl
 install -m 755 etcd %{buildroot}/usr/local/bin/etcd
+install -m 0600 -o etcd -g root etcd.conf %{buildroot}/etc/etcd.d/etcd.conf
+install -m 0644 etcd.service %{buildroot}/usr/lib/systemd/system
+install -d -m 0750 -o etcd -g root %{buildroot}/var/lib/etcd
 
 %files
-/usr/local/bin/etcdctl
-/usr/local/bin/etcd
+%attr(0755, root, root) /usr/local/bin/etcdctl
+%attr(0755, root, root) /usr/local/bin/etcd
+%attr(0644, root, root) /etc/etcd.d/etcd.conf
+/usr/lib/systemd/system/etcd.service
+%attr(0750, etcd, root) /var/lib/etcd
+
 %changelog


### PR DESCRIPTION
We now have a configuration file that etcd sources on start up, as well as a systemd service file. Tested and working on Centos 7 and Centos 8.